### PR TITLE
fix: Adjust repeating event calculation to include last occurrence

### DIFF
--- a/src/logic/calendar.ts
+++ b/src/logic/calendar.ts
@@ -25,7 +25,7 @@ function createCalEvent(calendar: ICalCalendar, row: TimeTableAPIRow) {
 	const endDate = new Date(new Date(endDateData).setHours(24, 0, 0, 0));
 	const repeatOptions: ICalRepeatingOptions = {
 		freq: ICalEventRepeatingFreq.WEEKLY,
-		until: utilTime,
+		until: endDate,
 	};
 
 	calendar.createEvent({

--- a/src/logic/calendar.ts
+++ b/src/logic/calendar.ts
@@ -21,10 +21,11 @@ function createCalEvent(calendar: ICalCalendar, row: TimeTableAPIRow) {
 	const eventEnd = new Date(Date.parse(`${startDateData}T${endTime}`));
 
 	// Use this to calculate repeating times
-	const endDate = new Date(Date.parse(endDateData));
+	// The UNTIL parameter is non-inclusive, so set untilTime to midnight after the endDate to include the last event occurrence
+	let utilTime = new Date(new Date(endDateData).setHours(24, 0, 0, 0));
 	const repeatOptions: ICalRepeatingOptions = {
 		freq: ICalEventRepeatingFreq.WEEKLY,
-		until: endDate,
+		until: utilTime,
 	};
 
 	calendar.createEvent({

--- a/src/logic/calendar.ts
+++ b/src/logic/calendar.ts
@@ -22,7 +22,7 @@ function createCalEvent(calendar: ICalCalendar, row: TimeTableAPIRow) {
 
 	// Use this to calculate repeating times
 	// The UNTIL parameter is non-inclusive, so set untilTime to midnight after the endDate to include the last event occurrence
-	let utilTime = new Date(new Date(endDateData).setHours(24, 0, 0, 0));
+	const endDate = new Date(new Date(endDateData).setHours(24, 0, 0, 0));
 	const repeatOptions: ICalRepeatingOptions = {
 		freq: ICalEventRepeatingFreq.WEEKLY,
 		until: utilTime,


### PR DESCRIPTION
- Updated untilTime calculation to set to midnight after endDate, ensuring the last event occurrence is included.
- Optimized code comments for clarity and readability.

Since the cause is the same, I've referenced the original explanation in this https://github.com/rayokamoto/AUDIT/pull/13#issuecomment-2286042558